### PR TITLE
Removing unused async tag from method

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -41,7 +41,7 @@ namespace AutoShutdown
         public static ConcurrentBag<string> MachinesWithTag = new ConcurrentBag<string>();
         public static ConcurrentBag<string> MachinesWithoutTag = new ConcurrentBag<string>();
 
-        public static async void AssertVms(AzureCredentials credentials, string subscriptionId)
+        public static void AssertVms(AzureCredentials credentials, string subscriptionId)
         {
             var azure = Azure
                     .Configure()


### PR DESCRIPTION
In order to avoid warnings:

```
/home/avarela/projects/azure-auto-shutdown/Program.cs(44,34): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.

Compilation succeeded.
    1 Warning(s)
    0 Error(s)

Time elapsed 00:00:01.1874652
```